### PR TITLE
Hoss 125 - RAD changes inline with internal accessibility audit

### DIFF
--- a/app/assets/stylesheets/modules/_javascript-related-styles.scss
+++ b/app/assets/stylesheets/modules/_javascript-related-styles.scss
@@ -19,41 +19,41 @@
     }
 }
 
-.form-field--error .error-notification {
+.form-group-error .error-notification {
     font-weight: bold;
     font-size: 19px;
     line-height: 1.31579;
 }
 
 .error,
-.form-field--error {
+.form-group-error {
     border-left: 5px solid #d4351c;
     padding-left: 15px;
     margin-right: 15px;
 }
 
-.form-field--error input[type="text"] {
+.form-group-error input[type="text"] {
     border: 4px solid #d4351c;
 }
 
-.form-field--error .form-date .form-field--error {
+.form-group-error .form-date .form-field-error {
     border-left: none;
     padding: inherit;
 }
 
-.form-field--error legend .heading-large {
+.form-group-error legend .heading-large {
     margin-top: 0px !important;
 }
 
-.form-field--error .multiple-choice [type="checkbox"] + label.form-field-single::before{
+.form-group-error .multiple-choice [type="checkbox"] + label.form-field-single::before{
     top: 0 !important;
 }
-.form-field--error .multiple-choice [type="checkbox"] + label.form-field-single::after {
+.form-group-error .multiple-choice [type="checkbox"] + label.form-field-single::after {
     top: 10px !important;
 }
 
 /* no js style for dates */
-.no-js .form-date .form-field--error {
+.no-js .form-date .form-group-error {
     border-left: none;
     padding: inherit;
     -webkit-box-sizing: inherit;
@@ -78,6 +78,10 @@
     margin: -1px;
     padding: 0;
     border: 0;
+}
+
+.form-group-error .error-notification {
+    display: block;
 }
 
 .form-control.width-full {

--- a/app/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendController.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendController.scala
@@ -161,14 +161,24 @@ object HomeOfficeSettledStatusFrontendController {
 
   import FormFieldMappings._
 
+  val wrap: (Nino, String, String, String, Option[StatusCheckRange]) => StatusCheckByNinoRequest = {
+    case (nino, gn, fn, db, range) => StatusCheckByNinoRequest.apply(db, fn, gn, nino, range)
+  }
+
+  val unwrap
+    : StatusCheckByNinoRequest => Option[(Nino, String, String, String, Option[StatusCheckRange])] =
+    StatusCheckByNinoRequest.unapply(_).map {
+      case (db, fn, gn, nino, range) => (nino, gn, fn, db, range)
+    }
+
   val StatusCheckByNinoRequestForm = Form[StatusCheckByNinoRequest](
     mapping(
-      "dateOfBirth" -> dateOfBirthMapping,
-      "familyName"  -> trimmedUppercaseName.verifying(validName("familyName", 3)),
-      "givenName"   -> trimmedUppercaseName.verifying(validName("givenName", 1)),
       "nino" -> uppercaseNormalizedText
         .verifying(validNino())
         .transform(Nino.apply, (n: Nino) => n.toString),
-      "range" -> ignored[Option[StatusCheckRange]](None)
-    )(StatusCheckByNinoRequest.apply)(StatusCheckByNinoRequest.unapply))
+      "givenName"   -> trimmedUppercaseName.verifying(validName("givenName", 1)),
+      "familyName"  -> trimmedUppercaseName.verifying(validName("familyName", 3)),
+      "dateOfBirth" -> dateOfBirthMapping,
+      "range"       -> ignored[Option[StatusCheckRange]](None)
+    )(wrap)(unwrap))
 }

--- a/app/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendController.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendController.scala
@@ -161,16 +161,6 @@ object HomeOfficeSettledStatusFrontendController {
 
   import FormFieldMappings._
 
-  val wrap: (Nino, String, String, String, Option[StatusCheckRange]) => StatusCheckByNinoRequest = {
-    case (nino, gn, fn, db, range) => StatusCheckByNinoRequest.apply(db, fn, gn, nino, range)
-  }
-
-  val unwrap
-    : StatusCheckByNinoRequest => Option[(Nino, String, String, String, Option[StatusCheckRange])] =
-    StatusCheckByNinoRequest.unapply(_).map {
-      case (db, fn, gn, nino, range) => (nino, gn, fn, db, range)
-    }
-
   val StatusCheckByNinoRequestForm = Form[StatusCheckByNinoRequest](
     mapping(
       "nino" -> uppercaseNormalizedText
@@ -180,5 +170,5 @@ object HomeOfficeSettledStatusFrontendController {
       "familyName"  -> trimmedUppercaseName.verifying(validName("familyName", 3)),
       "dateOfBirth" -> dateOfBirthMapping,
       "range"       -> ignored[Option[StatusCheckRange]](None)
-    )(wrap)(unwrap))
+    )(StatusCheckByNinoRequest.apply)(StatusCheckByNinoRequest.unapply))
 }

--- a/app/uk/gov/hmrc/homeofficesettledstatus/models/StatusCheckByNinoRequest.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/models/StatusCheckByNinoRequest.scala
@@ -20,14 +20,15 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.domain.Nino
 
 case class StatusCheckByNinoRequest(
-  // Date of birth of the person being checked in ISO 8601 format (can contain wildcards for day or month)
-  dateOfBirth: String,
-  // Family name required for search
-  familyName: String,
-  // Given name required for search
-  givenName: String,
   // National insurance number
   nino: Nino,
+  // Given name required for search
+  givenName: String,
+  // Family name required for search
+  familyName: String,
+  // Date of birth of the person being checked in ISO 8601 format (can contain wildcards for day or month)
+  dateOfBirth: String,
+  // Status check range, default to 6 months back
   statusCheckRange: Option[StatusCheckRange] = None
 )
 

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/LayoutComponents.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/LayoutComponents.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.homeofficesettledstatus.views
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.homeofficesettledstatus.views.html.main_template
 import uk.gov.hmrc.homeofficesettledstatus.views.html.helpers.Input
-import uk.gov.hmrc.play.views.html.helpers.{DateFieldsFreeInlineLegend, ErrorSummary, FormWithCSRF}
+import uk.gov.hmrc.homeofficesettledstatus.views.html.helpers.DateFieldsFreeInlineLegend
+import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF}
 
 @Singleton
 case class LayoutComponents @Inject()(

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/LayoutComponents.scala
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/LayoutComponents.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.homeofficesettledstatus.views
 
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.homeofficesettledstatus.views.html.main_template
-import uk.gov.hmrc.play.views.html.helpers.{DateFieldsFreeInlineLegend, ErrorSummary, FormWithCSRF, Input}
+import uk.gov.hmrc.homeofficesettledstatus.views.html.helpers.Input
+import uk.gov.hmrc.play.views.html.helpers.{DateFieldsFreeInlineLegend, ErrorSummary, FormWithCSRF}
 
 @Singleton
 case class LayoutComponents @Inject()(

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.homeofficesettledstatus.controllers.routes.HomeOfficeSettledStatusFrontendController
 @import play.api.Configuration
 @import uk.gov.hmrc.homeofficesettledstatus.models.StatusCheckByNinoRequest
-@import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF, Input}
+@import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF}
 @import uk.gov.hmrc.play.views.html.helpers.DateFieldsFreeInlineLegend
 @import uk.gov.hmrc.homeofficesettledstatus.views.LayoutComponents
 

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
@@ -18,7 +18,6 @@
 @import play.api.Configuration
 @import uk.gov.hmrc.homeofficesettledstatus.models.StatusCheckByNinoRequest
 @import uk.gov.hmrc.play.views.html.helpers.{ErrorSummary, FormWithCSRF}
-@import uk.gov.hmrc.play.views.html.helpers.DateFieldsFreeInlineLegend
 @import uk.gov.hmrc.homeofficesettledstatus.views.LayoutComponents
 
 @this(layout: LayoutComponents)

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
@@ -39,45 +39,37 @@
     @layout.form(
         action = submitFormCall, 'class -> "form js-form") {
 
-        <div class="form-group">
+        @layout.input(
+            statusCheckForm("nino"),
+            '_label -> Messages("lookup.nino.label"),
+            '_inputClass -> "form-control width-10",
+            '_labelTextClass -> "form-label",
+            '_inputHint -> Messages("lookup.nino.hint"),
+            '_labelClass -> "soft--ends"
+        )
+
          @layout.input(
-             statusCheckForm("nino"),
-             '_label -> Messages("lookup.nino.label"),
-             '_inputClass -> "form-control width-10",
-             '_labelTextClass -> "form-label",
-             '_inputHint -> Messages("lookup.nino.hint"),
-             '_labelClass -> "soft--ends"
+            statusCheckForm("givenName"),
+            '_label -> Messages("lookup.givenName.label"),
+            '_inputClass -> "form-control width-10",
+            '_labelTextClass -> "form-label",
+            '_labelClass -> "soft--ends"
          )
-         </div>
 
-         <div class="form-group">
-             @layout.input(
-                 statusCheckForm("givenName"),
-                 '_label -> Messages("lookup.givenName.label"),
-                 '_inputClass -> "form-control width-10",
-                 '_labelTextClass -> "form-label",
-                 '_labelClass -> "soft--ends"
-             )
-         </div>
+         @layout.input(
+            statusCheckForm("familyName"),
+            '_label -> Messages("lookup.familyName.label"),
+            '_inputClass -> "form-control width-10",
+            '_labelTextClass -> "form-label",
+            '_labelClass -> "soft--ends"
+         )
 
-         <div class="form-group">
-             @layout.input(
-                 statusCheckForm("familyName"),
-                 '_label -> Messages("lookup.familyName.label"),
-                 '_inputClass -> "form-control width-10",
-                 '_labelTextClass -> "form-label",
-                 '_labelClass -> "soft--ends"
-             )
-         </div>
-
-          <div class="@noJsDateFieldsError">
-             @layout.dateFieldsFreeInlineLegend(statusCheckForm, "dateOfBirth",
-                 '_legend -> Messages("lookup.dateOfBirth.label"),
-                 '_inputHint -> Messages("lookup.dateOfBirth.hint"),
-                 '_legendSpanClass -> "form-label",
-                 '_legendClass -> "flush--ends"
-             )
-          </div>
+         @layout.dateFieldsFreeInlineLegend(statusCheckForm, "dateOfBirth",
+            '_legend -> Messages("lookup.dateOfBirth.label"),
+            '_inputHint -> Messages("lookup.dateOfBirth.hint"),
+            '_legendSpanClass -> "form-label",
+            '_legendClass -> "flush--ends"
+         )
 
           <button class="button" type="submit" id="continue">@Messages("button.continue")</button>
 

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/StatusCheckByNinoPage.scala.html
@@ -28,7 +28,11 @@
     if(statusCheckForm("dateOfBirth.day").hasErrors || statusCheckForm("dateOfBirth.month").hasErrors || statusCheckForm("dateOfBirth.year").hasErrors) "nojs-date-fields-error" else ""
 }
 
-@layout.mainTemplate(title = Messages("lookup.title"), bodyClasses = Some("full-width")) {
+@messageTitle = @{
+    if(statusCheckForm.hasErrors) messages("generic.title.Error") else messages("lookup.title")
+}
+
+@layout.mainTemplate(title = messageTitle, bodyClasses = Some("full-width")) {
 
     <h1 class="heading-xlarge">@Messages("lookup.title")</h1>
 

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/DateFieldsFreeInlineLegend.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/DateFieldsFreeInlineLegend.scala.html
@@ -26,7 +26,7 @@
     Set(fieldName, s"${fieldName}.day", s"${fieldName}.month", s"${fieldName}.year")
 }
 
-@fieldsetClasses = @{if(formItem.hasErrors) "form-field--error" else "" }
+@fieldsetClasses = @{if(formItem.hasErrors) "form-group-error" else "" }
 
 <div class="form-group @fieldsetClasses soft--ends">
     <fieldset class="form-date" id="@fieldName">
@@ -46,46 +46,45 @@
             </span>}
         </legend>
 
-        <div class="form-group form-group-day">
-            @input(
-                formItem(s"${fieldName}.day"),
-                '_label -> Messages("date.fields.day"),
-                '_labelClass -> "form-group form-group-day",
-                '_inputClass -> "form-control input--xsmall",
-                '_emptyValueText -> " ",
-                '_type -> "tel",
-                '_maxlength -> "2",
-                '_hideErrors -> " ",
-                '_hideBar -> " "
-    
-            )
-        </div>
-        <div class="form-group form-group-month">
-            @input(
-                formItem(s"${fieldName}.month"),
-                '_label -> Messages("date.fields.month"),
-                '_labelClass -> "form-group form-group-month",
-                '_inputClass -> "form-control input--xsmall",
-                '_emptyValueText -> " ",
-                '_type -> "tel",
-                '_maxlength -> "2",
-                '_hideErrors -> " ",
-                '_hideBar -> " "
-            )
-        </div>
-        <div class="form-group form-group-year">
-            @input(
-                formItem(s"${fieldName}.year"),
-                '_label -> Messages("date.fields.year"),
-                '_labelClass -> "form-group form-group-year",
-                '_inputClass -> "form-control input--xsmall",
-                '_emptyValueText -> " ",
-                '_type -> "tel",
-                '_maxlength -> "4",
-                '_hideErrors -> " ",
-                '_hideBar -> " "
-            )
-        </div>
+        @input(
+            formItem(s"${fieldName}.day"),
+            '_label -> Messages("date.fields.day"),
+            '_labelClass -> "form-group form-group-day",
+            '_inputClass -> "form-control input--xsmall",
+            '_emptyValueText -> " ",
+            '_type -> "tel",
+            '_maxlength -> "2",
+            '_hideErrors -> " ",
+            '_hideBar -> " ",
+            '_divClass -> "form-group-day"
+        )
+
+        @input(
+            formItem(s"${fieldName}.month"),
+            '_label -> Messages("date.fields.month"),
+            '_labelClass -> "form-group form-group-month",
+            '_inputClass -> "form-control input--xsmall",
+            '_emptyValueText -> " ",
+            '_type -> "tel",
+            '_maxlength -> "2",
+            '_hideErrors -> " ",
+            '_hideBar -> " ",
+            '_divClass -> "form-group-month"
+        )
+
+        @input(
+            formItem(s"${fieldName}.year"),
+            '_label -> Messages("date.fields.year"),
+            '_labelClass -> "form-group form-group-year",
+            '_inputClass -> "form-control input--xsmall",
+            '_emptyValueText -> " ",
+            '_type -> "tel",
+            '_maxlength -> "4",
+            '_hideErrors -> " ",
+            '_hideBar -> " ",
+            '_divClass -> "form-group-year"
+        )
+
 
     </fieldset>
 </div>

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/DateFieldsFreeInlineLegend.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/DateFieldsFreeInlineLegend.scala.html
@@ -1,0 +1,91 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(input: Input)
+
+@(formItem:Form[_], fieldName: String, args: (Symbol,Any)*)(implicit messages: Messages)
+
+@import uk.gov.hmrc.play.mappers.DateFields._
+@import play.api.i18n._
+@import uk.gov.hmrc.play.mappers.DateFormatSymbols._
+
+@fieldNames = @{
+    Set(fieldName, s"${fieldName}.day", s"${fieldName}.month", s"${fieldName}.year")
+}
+
+@fieldsetClasses = @{if(formItem.hasErrors) "form-field--error" else "" }
+
+<div class="form-group @fieldsetClasses soft--ends">
+    <fieldset class="form-date" id="@fieldName">
+
+        <legend class="@args.toMap.get('_legendClass).map { legendClass => @legendClass}">
+            <span class="@args.toMap.get('_legendSpanClass).map { legendSpanClass => @legendSpanClass}">
+                @args.toMap.get('_legend).map { legend => @legend}
+            </span>
+            @args.toMap.get('_inputHint).map { hint =>
+                <span class="form-hint">@hint</span>
+            }
+            @formItem.errors.filter(error => fieldNames.contains(error.key)).map { error => <span class="error-notification">
+                @args.toMap.get('_errorPrefix).map { errorPrefix =>
+                    <span class="visually-hidden">@errorPrefix </span>
+                }
+                @Messages(error.message)
+            </span>}
+        </legend>
+
+        <div class="form-group form-group-day">
+            @input(
+                formItem(s"${fieldName}.day"),
+                '_label -> Messages("date.fields.day"),
+                '_labelClass -> "form-group form-group-day",
+                '_inputClass -> "form-control input--xsmall",
+                '_emptyValueText -> " ",
+                '_type -> "tel",
+                '_maxlength -> "2",
+                '_hideErrors -> " ",
+                '_hideBar -> " "
+    
+            )
+        </div>
+        <div class="form-group form-group-month">
+            @input(
+                formItem(s"${fieldName}.month"),
+                '_label -> Messages("date.fields.month"),
+                '_labelClass -> "form-group form-group-month",
+                '_inputClass -> "form-control input--xsmall",
+                '_emptyValueText -> " ",
+                '_type -> "tel",
+                '_maxlength -> "2",
+                '_hideErrors -> " ",
+                '_hideBar -> " "
+            )
+        </div>
+        <div class="form-group form-group-year">
+            @input(
+                formItem(s"${fieldName}.year"),
+                '_label -> Messages("date.fields.year"),
+                '_labelClass -> "form-group form-group-year",
+                '_inputClass -> "form-control input--xsmall",
+                '_emptyValueText -> " ",
+                '_type -> "tel",
+                '_maxlength -> "4",
+                '_hideErrors -> " ",
+                '_hideBar -> " "
+            )
+        </div>
+
+    </fieldset>
+</div>

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/Input.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/Input.scala.html
@@ -28,66 +28,68 @@
 @labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
 
 
-  @if(!labelAfter && elements.args.contains('_label)) {
-    @if(labelHighlight){<strong>}
-      <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if((elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) && !elements.args.contains('_hideBar)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
-        @elements.label
+  <div class="form-group @elements.args.get('_divClass) @if((elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) && !elements.args.contains('_hideBar)) {form-group-error}">
+    @if(!labelAfter && elements.args.contains('_label)) {
+      @if(labelHighlight){<strong>}
+        <label for="@elements.field.name" class="@if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) }" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+          @elements.label
 
-        @if(parentElements.isDefined) {
-          @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
-        }
-      </label>
-    @if(labelHighlight){</strong>}
-  }
-
-  @if(elements.args.contains('_inputHint) ){
-    <span class="form-hint"
-        @if(elements.args.contains('_hintId)) {
-            id="@elements.args.get('_hintId)"
-        }>
-        @elements.args.get('_inputHint)
-    </span>
-  }
-
-  @if(!elements.args.contains('_hideErrors)) {
-    @elements.errors.map { error =>
-      <span class="error-notification"
-          @if(elements.args.contains('_error_id)) {
-              id="@elements.args.get('_error_id)"
+          @if(parentElements.isDefined) {
+            @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
           }
-          role="tooltip"
-          data-journey="search-page:error:@elements.field.name">
-          @if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}
-          @Messages(error)
+        </label>
+      @if(labelHighlight){</strong>}
+    }
+
+    @if(elements.args.contains('_inputHint) ){
+      <span class="form-hint"
+          @if(elements.args.contains('_hintId)) {
+              id="@elements.args.get('_hintId)"
+          }>
+          @elements.args.get('_inputHint)
       </span>
     }
-  }
 
-  <input
-    @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
-    @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
-    @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
-    @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
-       name="@elements.field.name"
-       id="@elements.field.name"
-       value="@value"
-    @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
-    @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
-    @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
-    @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
-    @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
-    @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
-    @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
-    @if(elements.args.get('_required).isDefined) { required }
-       />
-
-  @if(labelAfter && elements.args.contains('_label)) {
-      @if(labelHighlight){<strong>}
-      <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
-          @elements.label
-      </span>
-      @if(elements.args.contains('_inputHint) ){
-          <span class="form-hint">@elements.args.get('_inputHint)</span>
+    @if(!elements.args.contains('_hideErrors)) {
+      @elements.errors.map { error =>
+        <span class="error-notification"
+            @if(elements.args.contains('_error_id)) {
+                id="@elements.args.get('_error_id)"
+            }
+            role="tooltip"
+            data-journey="search-page:error:@elements.field.name">
+            @if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}
+            @Messages(error)
+        </span>
       }
-      @if(labelHighlight){</strong>}
-  }
+    }
+
+    <input
+      @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+      @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+      @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+      @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+         name="@elements.field.name"
+         id="@elements.field.name"
+         value="@value"
+      @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+      @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+      @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+      @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
+      @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
+      @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+      @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+      @if(elements.args.get('_required).isDefined) { required }
+         />
+
+    @if(labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint">@elements.args.get('_inputHint)</span>
+        }
+        @if(labelHighlight){</strong>}
+    }
+  </div>

--- a/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/Input.scala.html
+++ b/app/uk/gov/hmrc/homeofficesettledstatus/views/helpers/Input.scala.html
@@ -1,0 +1,93 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit messages: Messages)
+
+@import views.html.helper._
+
+@elements = @{ new FieldElements(field.id, field, null, args.toMap, messages) }
+@parentField = @{args.toMap.get('parentField).asInstanceOf[Option[Field]]}
+@parentElements = @{parentField.map(pf => new FieldElements(pf.id, pf, null, Map(), messages) )}
+@value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
+@labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
+@labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
+
+
+  @if(!labelAfter && elements.args.contains('_label)) {
+    @if(labelHighlight){<strong>}
+      <label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if((elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) && !elements.args.contains('_hideBar)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+        @elements.label
+
+        @if(parentElements.isDefined) {
+          @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
+        }
+      </label>
+    @if(labelHighlight){</strong>}
+  }
+
+  @if(elements.args.contains('_inputHint) ){
+    <span class="form-hint"
+        @if(elements.args.contains('_hintId)) {
+            id="@elements.args.get('_hintId)"
+        }>
+        @elements.args.get('_inputHint)
+    </span>
+  }
+
+  @if(!elements.args.contains('_hideErrors)) {
+    @elements.errors.map { error =>
+      <span class="error-notification"
+          @if(elements.args.contains('_error_id)) {
+              id="@elements.args.get('_error_id)"
+          }
+          role="tooltip"
+          data-journey="search-page:error:@elements.field.name">
+          @if(elements.args.contains('_errorPrefix) ){<span class="visually-hidden">@elements.args.get('_errorPrefix) </span>}
+          @Messages(error)
+      </span>
+    }
+  }
+
+  <input
+    @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+    @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+    @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+    @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+       name="@elements.field.name"
+       id="@elements.field.name"
+       value="@value"
+    @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+    @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+    @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+    @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
+    @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
+    @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+    @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+    @if(elements.args.get('_required).isDefined) { required }
+       />
+
+  @if(labelAfter && elements.args.contains('_label)) {
+      @if(labelHighlight){<strong>}
+      <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+          @elements.label
+      </span>
+      @if(elements.args.contains('_inputHint) ){
+          <span class="form-hint">@elements.args.get('_inputHint)</span>
+      }
+      @if(labelHighlight){</strong>}
+  }

--- a/conf/messages
+++ b/conf/messages
@@ -6,6 +6,7 @@ generic.dob=Date of birth
 generic.nationality=Nationality
 generic.searchAgain=Search again
 generic.change=Change
+generic.title.Error=Error:
 
 # Validation errors
 error.summary.heading=There is a problem

--- a/conf/messages
+++ b/conf/messages
@@ -67,6 +67,6 @@ button.continue=Continue
 button.submit=Submit
 
 # Global errors
-global.error.500.title=Check Settled Status - GOV.UK
+global.error.500.title=Sorry, there is a problem with the service
 global.error.500.heading=Sorry, there is a problem with the service
 global.error.500.message=Try again later.

--- a/it/uk/gov/hmrc/homeofficesettledstatus/connectors/HomeOfficeSettledStatusConnectorISpec.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatus/connectors/HomeOfficeSettledStatusConnectorISpec.scala
@@ -126,10 +126,10 @@ trait HomeOfficeSettledStatusConnectorISpecSetup
     app.injector.instanceOf[HomeOfficeSettledStatusProxyConnector]
 
   val request = StatusCheckByNinoRequest(
-    "2001-01-31",
-    "JANE",
-    "DOE",
     Nino("RJ301829A"),
+    "DOE",
+    "JANE",
+    "2001-01-31",
     Some(
       StatusCheckRange(
         Some(LocalDate.now(ZoneId.of("UTC")).minusMonths(queryMonths)),

--- a/it/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendControllerISpec.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatus/controllers/HomeOfficeSettledStatusFrontendControllerISpec.scala
@@ -34,7 +34,7 @@ class HomeOfficeSettledStatusFrontendControllerISpec
       }
 
       "redirect to the clean lookup page when on status-check-failure" in {
-        val existingQuery = StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+        val existingQuery = StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
         journey.set(
           StatusCheckFailure("123", existingQuery, StatusCheckError(errCode = "ERR_NOT_FOUND")),
           List(StatusCheckByNino(), Start))
@@ -66,7 +66,7 @@ class HomeOfficeSettledStatusFrontendControllerISpec
       }
 
       "display the lookup page filled with existing query parameters" in {
-        val existingQuery = StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+        val existingQuery = StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
         journey.set(
           StatusCheckFailure("123", existingQuery, StatusCheckError(errCode = "ERR_NOT_FOUND")),
           List(StatusCheckByNino(), Start))
@@ -181,7 +181,7 @@ class HomeOfficeSettledStatusFrontendControllerISpec
 
       "redirect to start page if current state is StatusCheckFailure" in {
         val query =
-          StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+          StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
         val queryError = StatusCheckError(errCode = "ERR_NOT_FOUND")
         journey
           .set(
@@ -198,7 +198,7 @@ class HomeOfficeSettledStatusFrontendControllerISpec
 
       "display not found page" in {
         val query =
-          StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+          StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
         val queryError = StatusCheckError(errCode = "ERR_NOT_FOUND")
         journey
           .set(

--- a/it/uk/gov/hmrc/homeofficesettledstatus/stubs/JourneyTestData.scala
+++ b/it/uk/gov/hmrc/homeofficesettledstatus/stubs/JourneyTestData.scala
@@ -10,7 +10,7 @@ trait JourneyTestData {
   val correlationId: String = scala.util.Random.alphanumeric.take(64).toString()
 
   val validQuery =
-    StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+    StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
 
   val expectedResultWithSingleStatus = StatusCheckResult(
     fullName = "Jane Doe",

--- a/test/uk/gov/hmrc/homeofficesettledstatus/controllers/StatusCheckByNinoRequestFormSpec.scala
+++ b/test/uk/gov/hmrc/homeofficesettledstatus/controllers/StatusCheckByNinoRequestFormSpec.scala
@@ -24,11 +24,10 @@ import uk.gov.hmrc.play.test.UnitSpec
 class StatusCheckByNinoRequestFormSpec extends UnitSpec {
 
   val formOutput = StatusCheckByNinoRequest(
-    dateOfBirth = "1970-01-31",
-    familyName = "KOWALSKI",
+    nino = Nino("RJ301829A"),
     givenName = "JAN",
-    nino = Nino("RJ301829A")
-  )
+    familyName = "KOWALSKI",
+    dateOfBirth = "1970-01-31")
 
   val formInput1 = Map(
     "dateOfBirth.year"  -> "1970",

--- a/test/uk/gov/hmrc/homeofficesettledstatus/journey/HomeOfficeSettledStatusFrontendFormatSpec.scala
+++ b/test/uk/gov/hmrc/homeofficesettledstatus/journey/HomeOfficeSettledStatusFrontendFormatSpec.scala
@@ -51,7 +51,7 @@ class HomeOfficeSettledStatusFrontendFormatSpec extends UnitSpec {
       "StatusCheckByNino with query" in {
         val state =
           StatusCheckByNino(
-            Some(StatusCheckByNinoRequest("1956-05-08", "bar", "foo", Nino("RJ301829A"))))
+            Some(StatusCheckByNinoRequest(Nino("RJ301829A"), "foo", "bar", "1956-05-08")))
 
         val json = Json.parse(
           """{"state":"StatusCheckByNino","properties":{"maybeQuery":{"dateOfBirth":"1956-05-08","familyName":"bar","givenName":"foo","nino":"RJ301829A"}}}""")
@@ -62,7 +62,7 @@ class HomeOfficeSettledStatusFrontendFormatSpec extends UnitSpec {
       "StatusFound" in {
         val state = StatusFound(
           correlationId = "1234567890",
-          query = StatusCheckByNinoRequest("1956-05-08", "bar", "foo", Nino("RJ301829A")),
+          query = StatusCheckByNinoRequest(Nino("RJ301829A"), "foo", "bar", "1956-05-08"),
           result = StatusCheckResult(
             "Foo Bar",
             LocalDate.parse("1956-05-08"),
@@ -79,7 +79,7 @@ class HomeOfficeSettledStatusFrontendFormatSpec extends UnitSpec {
       "StatusCheckFailure" in {
         val state = StatusCheckFailure(
           correlationId = "1234567890",
-          query = StatusCheckByNinoRequest("1956-05-08", "bar", "foo", Nino("RJ301829A")),
+          query = StatusCheckByNinoRequest(Nino("RJ301829A"), "foo", "bar", "1956-05-08"),
           error = StatusCheckError("FOO_ERROR", Some(List(ValidationError("code1", "name1"))))
         )
 

--- a/test/uk/gov/hmrc/homeofficesettledstatus/journey/HomeOfficeSettledStatusFrontendModelSpec.scala
+++ b/test/uk/gov/hmrc/homeofficesettledstatus/journey/HomeOfficeSettledStatusFrontendModelSpec.scala
@@ -164,22 +164,22 @@ trait TestData {
   val correlationId = "123"
 
   val validQuery =
-    StatusCheckByNinoRequest("2001-01-31", "JANE", "DOE", Nino("RJ301829A"))
+    StatusCheckByNinoRequest(Nino("RJ301829A"), "DOE", "JANE", "2001-01-31")
 
   val validQueryWithDateRange =
     StatusCheckByNinoRequest(
-      "2001-01-31",
-      "JANE",
-      "DOE",
       Nino("RJ301829A"),
+      "DOE",
+      "JANE",
+      "2001-01-31",
       Some(
         StatusCheckRange(Some(LocalDate.now().minusDays(6)), Some(LocalDate.now().minusMonths(6)))))
 
   val strangeQuery =
-    StatusCheckByNinoRequest("1999-12-31", "FOO", "BAR", Nino("KA339738D"))
+    StatusCheckByNinoRequest(Nino("KA339738D"), "BAR", "FOO", "1999-12-31")
 
   val invalidQuery =
-    StatusCheckByNinoRequest("1982-12-12", "MARIA", "DOLL", Nino("AB888330D"))
+    StatusCheckByNinoRequest(Nino("AB888330D"), "DOLL", "MARIA", "1982-12-12")
 
   val expectedResult = StatusCheckResult(
     fullName = "Jane Doe",


### PR DESCRIPTION
These changes include:
- Update/add helpers to fix accessibility errors for screen readers when reading form labels
- Update error styling
- Prefix page title with Error: when the form page displays errors
- Re-order header errors to match order of input fields
- Update title of error page to match the h1