### PR TITLE
minor css specificity issue fix

### DIFF
--- a/app/assets/stylesheets/partials/_focus.scss
+++ b/app/assets/stylesheets/partials/_focus.scss
@@ -6,7 +6,8 @@
 
   a:focus,
   .error-summary .error-summary-list a:focus,
-  details summary:focus {
+  details summary:focus,
+  .flash.error-summary a:focus {
     outline: 3px solid transparent;
     color: #0b0c0c;
     background-color: #fd0;


### PR DESCRIPTION
which meant the focus colour of error link was render red instead of black

## Before
<img width="658" alt="Screenshot 2020-06-19 at 16 13 17" src="https://user-images.githubusercontent.com/1692222/85148489-1f418b00-b248-11ea-9c4f-068d8f2ae4c9.png">

## After
<img width="684" alt="Screenshot 2020-06-19 at 16 12 59" src="https://user-images.githubusercontent.com/1692222/85148507-25376c00-b248-11ea-8673-246c4f19cc02.png">
